### PR TITLE
Added preview feature: `--preview` before sending. Solves: #2

### DIFF
--- a/sent_log.csv
+++ b/sent_log.csv
@@ -1,3 +1,2 @@
 key,cced,timestamp
-edwin::low::rice.edu,True,2025-08-04T07:22:44.882736
-chris::low::rice.edu,False,2025-08-04T07:24:57.280493
+edwin::low::rice.edu,True,2025-08-04T08:22:58.261146

--- a/src/mailer_gmail.py
+++ b/src/mailer_gmail.py
@@ -1,3 +1,4 @@
+import argparse
 import csv
 import ssl
 import random
@@ -7,6 +8,10 @@ import os
 from datetime import datetime
 from email.message import EmailMessage
 from dotenv import load_dotenv
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--preview", action="store_true", help="Preview emails before sending")
+args = parser.parse_args()
 
 load_dotenv()
 USER = os.getenv("GMAIL_USER")
@@ -21,7 +26,7 @@ def load_sent_log():
     with open(LOG, newline="") as f:
         return {row["key"] for row in csv.DictReader(f)}
 
-def append_to_log(email, cced):
+def append_to_log(key, cced):
     write_header = not os.path.exists(LOG)
     with open(LOG, "a", newline="") as f:
         writer = csv.writer(f)
@@ -72,6 +77,19 @@ if __name__ == "__main__":
         cc_flag = p.get("cced", "").strip().lower() == "yes"
 
         print(f"Would send to {to_addr}{' (CC: Edwin)' if cc_flag else ''}")
+
+        print("\n--- Email Preview ---")
+        print(f"To     : {to_addr}")
+        print(f"Subject: {subj}")
+        print(f"Body   :\n{body}")
+        print("---------------------\n")
+
+        if args.preview:
+            confirm = input("Send this email? (y/n): ").strip().lower()
+            if confirm != "y":
+                print("Skipped.\n")
+                continue
+
         send_mail(to_addr, subj, body, cced=cc_flag)  # uncomment to actually send
         append_to_log(key, cc_flag)
 


### PR DESCRIPTION
This PR introduces a `--preview` flag that allows users to preview emails in the terminal before sending. When the flag is set, the script shows the recipient, subject, and body, and asks for confirmation before proceeding.

### Why this matters
- Helps catch mistakes in templates or formatting before sending.
- Prevents unintentional emails during testing.
- Useful for manual review or QA before batch outreach.