### PR TITLE
 Add `run_app.command` launcher for GUI

### DIFF
--- a/outreach/sent_log.csv
+++ b/outreach/sent_log.csv
@@ -21,4 +21,3 @@ qinwen::zhai::gs.com,False,2025-08-18T08:50:12.056971+00:00
 giacomo::ieronutti::gs.com,False,2025-08-18T08:59:33.502504+00:00
 nila::ramaswamy::gs.com,False,2025-08-18T09:05:12.882801+00:00
 mahdi::alidina::gs.com,False,2025-08-18T09:05:18.596870+00:00chris::low::rice.edu,yes
-chris::low::rice.edu,yes

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ rich
 InquirerPy
 pydantic
 pyyaml
+python-docx

--- a/run_app.command
+++ b/run_app.command
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+# always run from the repo this script lives in
+cd "$(dirname "$0")"
+
+# Ensure venv exists
+if [[ ! -x "venv/bin/python" ]]; then
+  /usr/bin/python3 -m venv venv
+  ./venv/bin/pip install -r requirements.txt
+fi
+
+# Launch the GUI with your venv
+exec ./venv/bin/python gui.py


### PR DESCRIPTION

**Description:**
This PR introduces a macOS–friendly launcher script (`run_app.command`) at the repo root. The script ensures the virtual environment exists, installs dependencies if missing, and launches `gui.py` with the correct interpreter.

**Changes:**

* Added `run_app.command` (executable, double-clickable on macOS)
* Script auto-creates `venv` if missing and installs `requirements.txt`
* Symlink example provided for convenient Desktop launcher

**Usage:**

1. Run once to make executable:

   ```bash
   chmod +x run_app.command
   ```
2. Double-click `run_app.command` in Finder, or symlink to Desktop:

   ```bash
   ln -sf "$PWD/run_app.command" ~/Desktop/Networking\ Automation.command
   ```

This improves usability by allowing the app to be launched without running `python gui.py` manually.
