### PR TITLE
Enable Prospect Editing + Fix Template Logic

### DIFF
--- a/outreach/prospects.csv
+++ b/outreach/prospects.csv
@@ -1,7 +1,6 @@
 first_name,last_name,company,role,company_domain,cced,template
-Chris,Low,Rice,Janitor,rice.edu,True,uchicago
+Chris,Low,Rice,Janitor,rice.edu,True,bulls
 Alexandra,Klimova,Goldman Sachs,Asset Management,gs.com,False,bulls
 Qinwen,Zhai,Goldman Sachs,Quant Strats,gs.com,False,bulls
 Giacomo,Ieronutti,Goldman Sachs,Asset Management,gs.com,False,bulls
 Nila,Ramaswamy,Goldman Sachs,Asset Management,gs.com,False,bulls
-Mahdi,Alidina,Goldman Sachs,Asset Management,gs.com,False,bulls


### PR DESCRIPTION
**Changes Introduced:**

1. **Prospect Editing in GUI**

   * Added functionality to open and modify `prospects.csv` directly in the GUI.
   * Eliminates the need for manual external editing.

2. **Template Selection Fix**

   * Updated logic so that the `template` column in `prospects.csv` is respected.
   * Correct template is now applied per prospect (e.g., Edwin, Bulls, UChicago).
   * Falls back to default only if the specified template file cannot be found.

**Why This Matters:**

* Improves workflow by letting users stay entirely in the GUI.
* Ensures emails use the intended template, avoiding mismatches.

**Testing Done:**

* Verified editing and saving prospects within the GUI updates `prospects.csv`.
* Verified that choosing `Edwin` in `prospects.csv` loads the Edwin template, not Bulls.
* Regression tested with Bulls and UChicago templates.


<img width="1016" height="602" alt="Screenshot 2025-08-20 at 4 32 11 PM" src="https://github.com/user-attachments/assets/33686057-55b1-4ab4-9e42-1352ad442bb5" />

